### PR TITLE
add catch all ipv4 rule to verify

### DIFF
--- a/test/shun/builder/address_test.exs
+++ b/test/shun/builder/address_test.exs
@@ -10,7 +10,8 @@ defmodule Shun.Builder.AddressTest do
     accept %URI{host: "localhost"}
     reject "192.168.1.1"
     reject {169, x, _, _} when x == 254
-    accept {_, _, _, _}
+    accept {127,0,0,1}
+    reject {_,_,_,_}
 
     reject {_, _, _, _, _, _, _, _}
   end


### PR DESCRIPTION
question - what takes precedence an ipv4 or ipv6 reject all rule at the end of the chain? 

Is there an implicit behavior if you fail to add a reject all rule ?