### PR TITLE
change verify_ips + add inverse test in instance_metadata_test

### DIFF
--- a/test/shun/preset/aws/instance_metadata_test.exs
+++ b/test/shun/preset/aws/instance_metadata_test.exs
@@ -34,5 +34,11 @@ defmodule Shun.Preset.AWS.InstanceMetadataTest do
     test "rejects resolved #{name} when used via Shun" do
       assert {:error, _} = Shun.verify(AddressVerifier, unquote(name))
     end
+
+  end
+
+  test "accepts non-aws metadata addresses" do
+    assert {:ok, _} = Shun.verify(AddressVerifier, "http://10.0.0.1")
+    assert {:ok, _} = Shun.verify(AddressVerifier, "http://www.google.com")
   end
 end


### PR DESCRIPTION
Found some time to investigate and I think `verify_ips` was trying to match on [:accept] instead of [{:ok, address}].
I assume the addresses could be different, so decided to reduce over them and bail out once one of them is rejected.
The added unit test fails without these changes. This fixes #4 for me